### PR TITLE
Center shuffle component

### DIFF
--- a/src/app/shuffle/shuffle.component.html
+++ b/src/app/shuffle/shuffle.component.html
@@ -1,5 +1,5 @@
-<section class="flex flex-col flex-wrap items-start">
-  <div class="flex flex-col md:flex-row md:items-start gap-8">
+<section class="flex flex-col flex-wrap items-center mt-8">
+  <div class="flex flex-col items-center md:flex-row md:items-start gap-8">
     <div class="w-full md:w-1/3">
       <app-shuffle-input-form (newItemEvent)="addItem($event)"></app-shuffle-input-form>
     </div>


### PR DESCRIPTION
## Summary
- center shuffle component content and add top margin

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68431db970f0832c9b490449a551ce2c