### PR TITLE
Make toolbar sticky and enable scrolling

### DIFF
--- a/src/app/layout/toolbar/toolbar.component.html
+++ b/src/app/layout/toolbar/toolbar.component.html
@@ -1,4 +1,4 @@
-<header>
+<header class="sticky top-0 z-10">
   <mat-toolbar color="primary">
     <mat-toolbar-row class="flex items-center">
       <button mat-icon-button (click)="toggle()">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,4 +6,7 @@
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-.main-content { min-height:100vh;}
+.main-content {
+  height: 100%;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- make toolbar sticky using `sticky top-0`
- allow scrolling in sidenav content

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684328002ab8832ca20924d5c7493e9d